### PR TITLE
Changes for RDF content negotiation

### DIFF
--- a/build/.htaccess
+++ b/build/.htaccess
@@ -3,12 +3,13 @@ Options -MultiViews
 
 # Directive to ensure *.rdf files served as appropriate content type,
 # if not present in main apache config
-AddType application/x-httpd-php  .html .htm .rdf .ttl
+AddType application/rdf+xml .rdf
+AddType text/turtle  .ttl
 
 <ifModule mod_rewrite.c>
- 	# Rewrite engine setup
- 	RewriteEngine On
-#	RewriteBase /2012/05/22
+	# Rewrite engine setup
+	RewriteEngine On
+	#RewriteBase /2012/05/22
 
 	# make sure we don't have the file or a directory index to serve
 	# the rest fails to redirect if we do
@@ -18,6 +19,7 @@ AddType application/x-httpd-php  .html .htm .rdf .ttl
 
 	# Rewrite rule to make sure we serve the turtle content when requested
 	RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+	RewriteCond %{HTTP_ACCEPT} application/rdf+turtle [OR]
 	RewriteCond %{HTTP_ACCEPT} application/turtle
 	RewriteRule ^(.*)$ %{REQUEST_URI}.ttl [R=303,L]
 
@@ -37,6 +39,12 @@ AddType application/x-httpd-php  .html .htm .rdf .ttl
 	RewriteRule ^(dctype)$ HTTP://%{HTTP_HOST}/documents/dcmi-terms\?v=dcmitype [R=303,L,NE,NC]
 	RewriteRule ^(dcam)$ HTTP://%{HTTP_HOST}/documents/dcmi-terms\?v=dcam [R=303,L,NE,NC]
 
-	# this catch-all means there's never a 404, any unservable request will serve dcmi-terms/index.html
+	# either of these catch-alls means there's never a 404
+	# any unservable request will serve dcmi-terms/index.html
 	RewriteRule ^(.*)$ HTTP://%{HTTP_HOST}/documents/dcmi-terms/ [R=303,L,NE]
+
+	#uncomment either the rule above or the rule below to control the default
+
+	# any unservable request will serve RDF Rurtle
+	#RewriteRule ^(.*)$ %{REQUEST_URI}.ttl [R=303,L]
 </ifModule>

--- a/build/.htaccess
+++ b/build/.htaccess
@@ -1,0 +1,42 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/x-httpd-php  .html .htm .rdf .ttl
+
+<ifModule mod_rewrite.c>
+ 	# Rewrite engine setup
+ 	RewriteEngine On
+#	RewriteBase /2012/05/22
+
+	# make sure we don't have the file or a directory index to serve
+	# the rest fails to redirect if we do
+	RewriteCond %{REQUEST_FILENAME} -f [OR]
+	RewriteCond %{REQUEST_FILENAME} -d 
+	RewriteRule .* - [L]
+
+	# Rewrite rule to make sure we serve the turtle content when requested
+	RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+	RewriteCond %{HTTP_ACCEPT} application/turtle
+	RewriteRule ^(.*)$ %{REQUEST_URI}.ttl [R=303,L]
+
+	# Rewrite rule to make sure we serve the RDF/XML content from the namespace URI by default
+	# if we get to here, yhey're getting RDF/xml
+	RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+	RewriteRule ^(.*)$ %{REQUEST_URI}.rdf [R=303,L]
+
+	# Rewrite rule to make sure we serve HTML content from the namespace URI if requested
+	RewriteCond %{HTTP_ACCEPT} text/html [OR]
+	RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+	RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+	# redirects all requests for individual vocabs to /dcmi-terms/
+	# which should serve /dcmi-terms/index.html
+	RewriteRule ^(dcelements)$ HTTP://%{HTTP_HOST}/documents/dcmi-terms?v=elements [R=303,L,NE,NC]
+	RewriteRule ^(dcterms)$ HTTP://%{HTTP_HOST}/documents/dcmi-terms\?v=terms [R=303,L,NE,NC]
+	RewriteRule ^(dctype)$ HTTP://%{HTTP_HOST}/documents/dcmi-terms\?v=dcmitype [R=303,L,NE,NC]
+	RewriteRule ^(dcam)$ HTTP://%{HTTP_HOST}/documents/dcmi-terms\?v=dcam [R=303,L,NE,NC]
+
+	# this catch-all means there's never a 404, any unservable request will serve dcmi-terms/index.html
+	RewriteRule ^(.*)$ HTTP://%{HTTP_HOST}/documents/dcmi-terms/ [R=303,L,NE]
+</ifModule>

--- a/build/html/dcmi-terms/index.shtml
+++ b/build/html/dcmi-terms/index.shtml
@@ -8318,6 +8318,8 @@ of semantic specifications and related DCMI documents [<a href="#TRANSLATIONS">T
 </tbody>
 </table>
 </div>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript"></script>
+<script src="jump2location.js" type="text/javascript"></script>
 <!--#include virtual="/ssi/footer.shtml" -->
 </body>
 </html>

--- a/build/html/dcmi-terms/jump2location.js
+++ b/build/html/dcmi-terms/jump2location.js
@@ -1,0 +1,16 @@
+//jump2location.js
+
+$(document).ready(function () {
+  var vocab = getParameterByName("v");
+  var hash = window.location.hash;
+  if (vocab && hash) {
+    var jump = "#" + vocab + "-" + hash.replace(/^#/, '');
+    var new_position = $(jump).offset();
+    window.scrollTo(new_position.left, new_position.top);
+  }
+});
+function getParameterByName (name) {
+  var match = RegExp('[?&]' + name + '=([^&]*)')
+      .exec(window.location.search);
+  return match && decodeURIComponent(match[1].replace(/\+/g, ' '));
+}

--- a/web/xsl/html-dcmiterms.xsl
+++ b/web/xsl/html-dcmiterms.xsl
@@ -1,260 +1,348 @@
-<?xml version="1.0" encoding="utf-8" ?>
-
-<xsl:transform
-	version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:xhtml="http://www.w3.org/1999/xhtml"
-	>
-	
-<!-- gk: HTML5 really shouldn't have either system or public DOCTYPE elements, but removing these results in no DOCTYPE -->
-<xsl:output
-	method="xml"
-	indent="yes"
-	version="1.0"
-	encoding="utf-8"
-	/>
-
-<xsl:namespace-alias result-prefix="xhtml" stylesheet-prefix="#default" />
-
-<xsl:param name="todaysDate" select="substring-before(document('http://xobjex.com/service/date.xsl')/date/utc/@stamp,'T')"/>
-
-<xsl:param name="datestamp.dir" select="concat('../../',$todaysDate)" />
-<xsl:param name="sect.dir" select="concat($datestamp.dir,'/xmldata')" />
-<xsl:param name="intro.file" select="concat($datestamp.dir,'/headers/intro.dcmi-terms.xml')" />
-
-<xsl:param name="section2"	select="concat($sect.dir,'/dcterms-properties.xml')" />
-<xsl:param name="section3"	select="concat($sect.dir,'/dcelements.xml')" />
-<xsl:param name="section4"	select="concat($sect.dir,'/dcterms-ves.xml')" />
-<xsl:param name="section5"	select="concat($sect.dir,'/dcterms-ses.xml')" />
-<xsl:param name="section6"	select="concat($sect.dir,'/dcterms-classes.xml')" />
-<xsl:param name="section7"	select="concat($sect.dir,'/dctype.xml')" />
-<xsl:param name="section8"	select="concat($sect.dir,'/dcam.xml')" />
-
-<xsl:param name="test.hostname" /> <!-- mainly so I can hook into the http://dublincore.org CSS file(s) when testing -->
-
-<xsl:variable name="sec2-doc" select="document($section2)" />
-<xsl:variable name="sec3-doc" select="document($section3)" />
-<xsl:variable name="sec4-doc" select="document($section4)" />
-<xsl:variable name="sec5-doc" select="document($section5)" />
-<xsl:variable name="sec6-doc" select="document($section6)" />
-<xsl:variable name="sec7-doc" select="document($section7)" />
-<xsl:variable name="sec8-doc" select="document($section8)"/>
-
-<xsl:variable name="intro" select="document($intro.file)" />
-
-<xsl:key name="map" match="match[not(../@context)]" use="@element" />
-
-<xsl:include href="html-common.xsl" />
-<xsl:include href="html-regular.xsl" />
-
-<xsl:template match="/">
-  <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html>&#10;</xsl:text>
-	<html
-    prefix="dcam: http://purl.org/dc/dcam/ dctype: http://purl.org/dc/dcmitype/"
-    lang="en"
-    resource="http://purl.org/dc/"
-  >
-		<head>
-			<title>
-				<xsl:apply-templates select="H1/Title"/>
-			</title>
-			<xsl:comment>#exec cgi="/cgi-bin/metawriter.cgi" </xsl:comment>
-			<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-			<link rel="stylesheet" href="{$test.hostname}/css/default.css" type="text/css" />
-			<link rel="dcterms:tableOfContents" href="#contents" title="Table of Contents" /> <!-- see note at #contents below re not implementing this as an RDFa @property -->
-			<style type="text/css"> <!-- FIXME: this inline style is for development only, and it should be placed inside the stylesheet referenced above -->
-				<![CDATA[
-				tr.attribute th {
-					background-color: #fff;
-				}
-				table.legend,
-				table.references {
-					margin-left: 2.5%;
-					margin-right: 2.5%;
-					width: 95%;
-					table-layout:fixed;
-					border-width: 0;
-					}
-				.legend th.label,
-				.references th.abbrev {
-					width: 20%;
-				}
-				.legend td.definition,
-				.references td.citation {
-					width: 80%;
-				}
-				abbr.xmlns {
-					font-style: italic;
-					border-bottom: 0;
-				}
-				table.border.index td,
-				table.border.index th {
-					border-spacing: 0;
-				}
-				table.index th {
-					border-right: 1px solid #CCC; border-bottom: 1px solid #CCC; padding: .5em; /* FIXME: if this selector gets added to table.border th, then these duplicate CSS settings won't be needed. The ones below are the overrides */
-					font-weight: normal;
-					background-color: transparent;
-				}
-				]]>
-			</style>
-		</head>
-		<body>
-			<xsl:comment>#include virtual="/ssi/header.shtml" </xsl:comment>
-			<h1><xsl:apply-templates select="H1/Title" /></h1>
-			<xsl:apply-templates select="H1" mode="docinfo" />
-			<xsl:call-template name="tableOfContents" />
-			<xsl:call-template name="indexOfTerms" />
-			<xsl:call-template name="introSection" />
-			<xsl:call-template name="mainSections" />
-			<xsl:comment>#include virtual="/ssi/footer.shtml" </xsl:comment>
-		</body>
-	</html>
-</xsl:template>
-
-<xsl:template match="xhtml:html">
-	<xsl:copy-of select="xhtml:body/*" />
-</xsl:template>
-
-<xsl:template name="tableOfContents">
-	<div id="contents"> <!-- CHECKME: had @property = "dcterms:tableOfContents" here, which check.rdfa.info liked, but it's value was XHTML markup, doesn't seem exactly right -->
-		<h2>Table of Contents</h2>
-		<ol>
-			<li><a href="#H1">Introduction and Definitions</a></li>
-			<li><a href="#H2"><xsl:apply-templates select="$sec2-doc" mode="heading" /></a></li>
-			<li><a href="#H3"><xsl:apply-templates select="$sec3-doc" mode="heading" /></a></li>
-			<li><a href="#H4"><xsl:apply-templates select="$sec4-doc" mode="heading" /></a></li>
-			<li><a href="#H5"><xsl:apply-templates select="$sec5-doc" mode="heading" /></a></li>
-			<li><a href="#H6"><xsl:apply-templates select="$sec6-doc" mode="heading" /></a></li>
-			<li><a href="#H7"><xsl:apply-templates select="$sec7-doc" mode="heading" /></a></li>
-			<li><a href="#H8"><xsl:apply-templates select="$sec8-doc" mode="heading" /></a></li>
-			<!--
-			<li><a href="http://dublincore.org/dcregistry/navigateServlet?reqType=termsOverviewServlet">DCMI Terms Overview</a></li>
-			-->
-		</ol>
-	</div>
-</xsl:template>
-
-<xsl:template match="dc" mode="heading">
-	<xsl:copy-of select="heading/node()" />
-</xsl:template>
-
-<xsl:template name="indexOfTerms">
-	<h2>Index of Terms</h2>
-	<table class="border index">
-		<xsl:apply-templates select="$sec2-doc" mode="index">
-			<xsl:with-param name="propertiesOnly" select="true()" />
-		</xsl:apply-templates>
-		<xsl:apply-templates select="$sec3-doc" mode="index">
-			<xsl:with-param name="propertiesOnly" select="true()" />
-		</xsl:apply-templates>
-		<xsl:apply-templates select="$sec4-doc" mode="index" />
-		<xsl:apply-templates select="$sec5-doc" mode="index" />
-		<xsl:apply-templates select="$sec6-doc" mode="index" />
-		<xsl:apply-templates select="$sec7-doc" mode="index" />
-		<xsl:apply-templates select="$sec8-doc" mode="index" />
-	</table>
-</xsl:template>
-
-<xsl:template match="dc" mode="index">
-	<xsl:param name="propertiesOnly" />
-	<tr>
-		<th scope="row"><xsl:apply-templates select="." mode="heading" /></th>
-		<td>
-			<xsl:apply-templates select="term[
-				not(Is-Replaced-By) and
-				(
-					not($propertiesOnly) or
-					substring-after(Type-of-Term, '#') = 'Property'
-				)
-			]"
-			mode="index"
-			>
-				<xsl:sort select="Name"/>
-			</xsl:apply-templates>
-		</td>
-	</tr>
-</xsl:template>
-
-<xsl:template match="term" mode="index">
-	<xsl:if test="position() &gt; 1">
-		<xsl:text>, </xsl:text>
-	</xsl:if>
-	<a href="#{Name-for-Table}" class="term">
-		<xsl:value-of select="Name"/>
-	</a>
-</xsl:template>
-
-<xsl:template name="introSection">
-	<div id="H1">
-		<h2>Section 1: Introduction and Definitions</h2>
-		<xsl:apply-templates select="$intro/xhtml:html" />
-	</div>
-</xsl:template>
-
-<xsl:template name="mainSections">
-	<xsl:apply-templates select="$sec2-doc/dc">
-		<xsl:with-param name="propertiesOnly" select="true()" />
-		<xsl:with-param name="seq" select="2" />
-	</xsl:apply-templates>
-	<xsl:apply-templates select="$sec3-doc/dc">
-		<xsl:with-param name="propertiesOnly" select="true()" />
-		<xsl:with-param name="seq" select="3" />
-	</xsl:apply-templates>
-	<xsl:apply-templates select="$sec4-doc/dc">
-		<xsl:with-param name="seq" select="4" />
-	</xsl:apply-templates>
-	<xsl:apply-templates select="$sec5-doc/dc">
-		<xsl:with-param name="seq" select="5" />
-	</xsl:apply-templates>
-	<xsl:apply-templates select="$sec6-doc/dc">
-		<xsl:with-param name="seq" select="6" />
-	</xsl:apply-templates>
-	<xsl:apply-templates select="$sec7-doc/dc">
-		<xsl:with-param name="seq" select="7" />
-	</xsl:apply-templates>
-	<xsl:apply-templates select="$sec8-doc/dc">
-		<xsl:with-param name="seq" select="8" />
-	</xsl:apply-templates>
-</xsl:template>
-
-<xsl:template match="dc">
-	<xsl:param name="propertiesOnly" />
-	<xsl:param name="seq" select="1" /> <!-- a bit unfortunate, needing this -->
-	<div id="H{$seq}">
-		<h2>Section <xsl:value-of select="$seq" />: <xsl:apply-templates select="." mode="heading" /></h2>
-		<table cellspacing="0" class="border">
-			<xsl:apply-templates select="term[
-				not(Is-Replaced-By) and
-					(
-					not($propertiesOnly) or
-					substring-after(Type-of-Term, '#') = 'Property'
-					)
-				]
-			">
-				<xsl:sort select="Name"/>
-			</xsl:apply-templates>
-		</table>
-	</div>
-</xsl:template>
-
-<xsl:template match="term">
-	<tbody id="{Name-for-Table}" class="term" resource="{URI}">
-		<tr>
-			<th colspan="2" scope="rowgroup">
-				<xsl:text>Term Name: </xsl:text>
-				<xsl:text disable-output-escaping="yes">&amp;nbsp;&amp;nbsp;</xsl:text>
-				<span>
-					<xsl:apply-templates select="key('map','Name')" />
-					<xsl:value-of select="Name"/>
-				</span>
-				<!-- FIXME: really can't work out why I should need to populate @select here. Would be more robust without it. If I leave it out, the text contents of every other <term/> child node are output. halp! -->
-				<xsl:apply-templates select="Date-Modified | Date-Issued | Namespace" mode="content" />
-			</th>
-		</tr>
-		<xsl:apply-templates />
-	</tbody>
-</xsl:template>
-
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:transform version="1.0"
+               xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+               xmlns="http://www.w3.org/1999/xhtml"
+               xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <!-- gk: HTML5 really shouldn't have either system or public DOCTYPE elements, but removing these results in no DOCTYPE -->
+  <xsl:output method="xml"
+              indent="yes"
+              version="1.0"
+              encoding="utf-8" />
+  <xsl:namespace-alias result-prefix="xhtml"
+                       stylesheet-prefix="#default" />
+  <xsl:param name="todaysDate"
+             select="substring-before(document('http://xobjex.com/service/date.xsl')/date/utc/@stamp,'T')" />
+  <xsl:param name="datestamp.dir"
+             select="concat('../../',$todaysDate)" />
+  <xsl:param name="sect.dir"
+             select="concat($datestamp.dir,'/xmldata')" />
+  <xsl:param name="intro.file"
+             select="concat($datestamp.dir,'/headers/intro.dcmi-terms.xml')" />
+  <xsl:param name="section2"
+             select="concat($sect.dir,'/dcterms-properties.xml')" />
+  <xsl:param name="section3"
+             select="concat($sect.dir,'/dcelements.xml')" />
+  <xsl:param name="section4"
+             select="concat($sect.dir,'/dcterms-ves.xml')" />
+  <xsl:param name="section5"
+             select="concat($sect.dir,'/dcterms-ses.xml')" />
+  <xsl:param name="section6"
+             select="concat($sect.dir,'/dcterms-classes.xml')" />
+  <xsl:param name="section7"
+             select="concat($sect.dir,'/dctype.xml')" />
+  <xsl:param name="section8"
+             select="concat($sect.dir,'/dcam.xml')" />
+  <xsl:param name="test.hostname" />
+  <!-- mainly so I can hook into the http://dublincore.org CSS file(s) when testing -->
+  <xsl:variable name="sec2-doc"
+                select="document($section2)" />
+  <xsl:variable name="sec3-doc"
+                select="document($section3)" />
+  <xsl:variable name="sec4-doc"
+                select="document($section4)" />
+  <xsl:variable name="sec5-doc"
+                select="document($section5)" />
+  <xsl:variable name="sec6-doc"
+                select="document($section6)" />
+  <xsl:variable name="sec7-doc"
+                select="document($section7)" />
+  <xsl:variable name="sec8-doc"
+                select="document($section8)" />
+  <xsl:variable name="intro"
+                select="document($intro.file)" />
+  <xsl:key name="map"
+           match="match[not(../@context)]"
+           use="@element" />
+  <xsl:include href="html-common.xsl" />
+  <xsl:include href="html-regular.xsl" />
+  <xsl:template match="/">
+    <xsl:text disable-output-escaping='yes'>
+&lt;!DOCTYPE html&gt;
+</xsl:text>
+    <html prefix="dcam: http://purl.org/dc/dcam/ dctype: http://purl.org/dc/dcmitype/"
+          lang="en"
+          resource="http://purl.org/dc/">
+      <head>
+        <title>
+          <xsl:apply-templates select="H1/Title" />
+        </title>
+        <xsl:comment>#exec cgi="/cgi-bin/metawriter.cgi"</xsl:comment>
+        <meta http-equiv="Content-Type"
+              content="text/html; charset=utf-8" />
+        <link rel="stylesheet"
+              href="{$test.hostname}/css/default.css"
+              type="text/css" />
+        <link rel="dcterms:tableOfContents"
+              href="#contents"
+              title="Table of Contents" />
+        <!-- see note at #contents below re not implementing this as an RDFa @property -->
+        <style type="text/css">
+          <!-- FIXME: this inline style is for development only, and it should be placed inside the stylesheet referenced above -->
+          <![CDATA[
+                                tr.attribute th {
+                                        background-color: #fff;
+                                }
+                                table.legend,
+                                table.references {
+                                        margin-left: 2.5%;
+                                        margin-right: 2.5%;
+                                        width: 95%;
+                                        table-layout:fixed;
+                                        border-width: 0;
+                                        }
+                                .legend th.label,
+                                .references th.abbrev {
+                                        width: 20%;
+                                }
+                                .legend td.definition,
+                                .references td.citation {
+                                        width: 80%;
+                                }
+                                abbr.xmlns {
+                                        font-style: italic;
+                                        border-bottom: 0;
+                                }
+                                table.border.index td,
+                                table.border.index th {
+                                        border-spacing: 0;
+                                }
+                                table.index th {
+                                        border-right: 1px solid #CCC; border-bottom: 1px solid #CCC; padding: .5em; /* FIXME: if this selector gets added to table.border th, then these duplicate CSS settings won't be needed. The ones below are the overrides */
+                                        font-weight: normal;
+                                        background-color: transparent;
+                                }
+                                ]]>
+</style>
+      </head>
+      <body>
+        <xsl:comment>#include virtual="/ssi/header.shtml"</xsl:comment>
+        <h1>
+          <xsl:apply-templates select="H1/Title" />
+        </h1>
+        <xsl:apply-templates select="H1"
+                             mode="docinfo" />
+        <xsl:call-template name="tableOfContents" />
+        <xsl:call-template name="indexOfTerms" />
+        <xsl:call-template name="introSection" />
+        <xsl:call-template name="mainSections" />
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"
+                type="text/javascript"></script>
+        <script src="jump2location.js"
+                type="text/javascript"></script>
+        <xsl:comment>#include virtual="/ssi/footer.shtml"</xsl:comment>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template match="xhtml:html">
+    <xsl:copy-of select="xhtml:body/*" />
+  </xsl:template>
+  <xsl:template name="tableOfContents">
+    <div id="contents">
+      <!-- CHECKME: had @property = "dcterms:tableOfContents" here, which check.rdfa.info liked, but it's value was XHTML markup, doesn't seem exactly right -->
+      <h2>Table of Contents</h2>
+      <ol>
+        <li>
+          <a href="#H1">Introduction and Definitions</a>
+        </li>
+        <li>
+          <a href="#H2">
+            <xsl:apply-templates select="$sec2-doc"
+                                 mode="heading" />
+          </a>
+        </li>
+        <li>
+          <a href="#H3">
+            <xsl:apply-templates select="$sec3-doc"
+                                 mode="heading" />
+          </a>
+        </li>
+        <li>
+          <a href="#H4">
+            <xsl:apply-templates select="$sec4-doc"
+                                 mode="heading" />
+          </a>
+        </li>
+        <li>
+          <a href="#H5">
+            <xsl:apply-templates select="$sec5-doc"
+                                 mode="heading" />
+          </a>
+        </li>
+        <li>
+          <a href="#H6">
+            <xsl:apply-templates select="$sec6-doc"
+                                 mode="heading" />
+          </a>
+        </li>
+        <li>
+          <a href="#H7">
+            <xsl:apply-templates select="$sec7-doc"
+                                 mode="heading" />
+          </a>
+        </li>
+        <li>
+          <a href="#H8">
+            <xsl:apply-templates select="$sec8-doc"
+                                 mode="heading" />
+          </a>
+        </li>
+        <!--
+                        <li><a href="http://dublincore.org/dcregistry/navigateServlet?reqType=termsOverviewServlet">DCMI Terms Overview</a></li>
+                        -->
+      </ol>
+    </div>
+  </xsl:template>
+  <xsl:template match="dc"
+                mode="heading">
+    <xsl:copy-of select="heading/node()" />
+  </xsl:template>
+  <xsl:template name="indexOfTerms">
+    <h2>Index of Terms</h2>
+    <table class="border index">
+      <xsl:apply-templates select="$sec2-doc"
+                           mode="index">
+        <xsl:with-param name="propertiesOnly"
+                        select="true()" />
+      </xsl:apply-templates>
+      <xsl:apply-templates select="$sec3-doc"
+                           mode="index">
+        <xsl:with-param name="propertiesOnly"
+                        select="true()" />
+      </xsl:apply-templates>
+      <xsl:apply-templates select="$sec4-doc"
+                           mode="index" />
+      <xsl:apply-templates select="$sec5-doc"
+                           mode="index" />
+      <xsl:apply-templates select="$sec6-doc"
+                           mode="index" />
+      <xsl:apply-templates select="$sec7-doc"
+                           mode="index" />
+      <xsl:apply-templates select="$sec8-doc"
+                           mode="index" />
+    </table>
+  </xsl:template>
+  <xsl:template match="dc"
+                mode="index">
+    <xsl:param name="propertiesOnly" />
+    <tr>
+      <th scope="row">
+        <xsl:apply-templates select="."
+                             mode="heading" />
+      </th>
+      <td>
+        <xsl:apply-templates select="term[
+                                not(Is-Replaced-By) and
+                                (
+                                        not($propertiesOnly) or
+                                        substring-after(Type-of-Term, '#') = 'Property'
+                                )
+                        ]"
+                             mode="index">
+          <xsl:sort select="Name" />
+        </xsl:apply-templates>
+      </td>
+    </tr>
+  </xsl:template>
+  <xsl:template match="term"
+                mode="index">
+    <xsl:if test="position() &gt; 1">
+      <xsl:text>
+, 
+</xsl:text>
+    </xsl:if>
+    <a href="#{Name-for-Table}"
+       class="term">
+      <xsl:value-of select="Name" />
+    </a>
+  </xsl:template>
+  <xsl:template name="introSection">
+    <div id="H1">
+      <h2>Section 1: Introduction and Definitions</h2>
+      <xsl:apply-templates select="$intro/xhtml:html" />
+    </div>
+  </xsl:template>
+  <xsl:template name="mainSections">
+    <xsl:apply-templates select="$sec2-doc/dc">
+      <xsl:with-param name="propertiesOnly"
+                      select="true()" />
+      <xsl:with-param name="seq"
+                      select="2" />
+    </xsl:apply-templates>
+    <xsl:apply-templates select="$sec3-doc/dc">
+      <xsl:with-param name="propertiesOnly"
+                      select="true()" />
+      <xsl:with-param name="seq"
+                      select="3" />
+    </xsl:apply-templates>
+    <xsl:apply-templates select="$sec4-doc/dc">
+      <xsl:with-param name="seq"
+                      select="4" />
+    </xsl:apply-templates>
+    <xsl:apply-templates select="$sec5-doc/dc">
+      <xsl:with-param name="seq"
+                      select="5" />
+    </xsl:apply-templates>
+    <xsl:apply-templates select="$sec6-doc/dc">
+      <xsl:with-param name="seq"
+                      select="6" />
+    </xsl:apply-templates>
+    <xsl:apply-templates select="$sec7-doc/dc">
+      <xsl:with-param name="seq"
+                      select="7" />
+    </xsl:apply-templates>
+    <xsl:apply-templates select="$sec8-doc/dc">
+      <xsl:with-param name="seq"
+                      select="8" />
+    </xsl:apply-templates>
+  </xsl:template>
+  <xsl:template match="dc">
+    <xsl:param name="propertiesOnly" />
+    <xsl:param name="seq"
+               select="1" />
+    <!-- a bit unfortunate, needing this -->
+    <div id="H{$seq}">
+      <h2>Section 
+      <xsl:value-of select="$seq" />: 
+      <xsl:apply-templates select="."
+                           mode="heading" /></h2>
+      <table cellspacing="0"
+             class="border">
+        <xsl:apply-templates select="term[
+                                not(Is-Replaced-By) and
+                                        (
+                                        not($propertiesOnly) or
+                                        substring-after(Type-of-Term, '#') = 'Property'
+                                        )
+                                ]
+                        ">
+          <xsl:sort select="Name" />
+        </xsl:apply-templates>
+      </table>
+    </div>
+  </xsl:template>
+  <xsl:template match="term">
+    <tbody id="{Name-for-Table}"
+           class="term"
+           resource="{URI}">
+      <tr>
+        <th colspan="2"
+            scope="rowgroup">
+          <xsl:text>
+Term Name: 
+</xsl:text>
+          <xsl:text disable-output-escaping="yes">
+&amp;nbsp;&amp;nbsp;
+</xsl:text>
+          <span>
+            <xsl:apply-templates select="key('map','Name')" />
+            <xsl:value-of select="Name" />
+          </span>
+          <!-- FIXME: really can't work out why I should need to populate @select here. Would be more robust without it. If I leave it out, the text contents of every other <term/> child node are output. halp! -->
+          <xsl:apply-templates select="Date-Modified | Date-Issued | Namespace"
+                               mode="content" />
+        </th>
+      </tr>
+      <xsl:apply-templates />
+    </tbody>
+  </xsl:template>
 </xsl:transform>


### PR DESCRIPTION
Added javascript load to the bottom of `dcmi-terms/index.shtml` and `html-dcmiterms.xsl`
Created javascript file
Created `.htaccess` file to be colocated with RDF files in /build/ folder to handle basic content negotiation for html, RDF/XML, and Turtle based on redirects from purl.org/dc/... 
